### PR TITLE
Add noscript fallback message for non-JS users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/index.html
+++ b/index.html
@@ -12,6 +12,11 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   </head>
   <body class="bg-black text-white font-display selection:bg-brand-400/30 selection:text-white">
+    <noscript>
+      <div class="bg-white text-black p-2 text-center">
+        This site requires JavaScript to display content.
+      </div>
+    </noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>


### PR DESCRIPTION
## Summary
- add noscript notice so visitors without JavaScript see a readable message
- ignore build artifacts and dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1eeccbb14833199d8dd7b0aa5ab1f