### PR TITLE
Simplify pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,19 +16,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          # cache: 'npm'   # <- optional; keep only if package-lock.json is committed
-      - name: Install
-        run: npm ci || npm i
-      - name: Build
-        run: npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: .
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- remove Node setup, install, and build steps from GitHub Pages workflow
- upload repository root directly as artifact

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a80e53b0688331b05ea847ec57e39b