### PR TITLE
fix theme palette definitions for light and dark modes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,13 @@
 :root {
-  --bg: #0a192f;
-  --text: #ffffff;
+  --bg: #ffffff;
+  --text: #1f2937;
   --accent: #06b6d4;
   --accent-secondary: #7c3aed;
 }
 
 html.dark {
-  --bg: #ffffff;
-  --text: #1f2937;
+  --bg: #0a192f;
+  --text: #ffffff;
 }
 
 body {


### PR DESCRIPTION
## Summary
- swap light and dark variable palettes so light mode is default and dark mode activates via `.dark`

## Testing
- `npm run build`
- `node - <<'NODE'
const fs = require('fs');
const {JSDOM} = require('jsdom');
const css = fs.readFileSync('src/index.css', 'utf8');
const dom = new JSDOM(`<!doctype html><html><head><style>${css}</style></head><body></body></html>`);
const document = dom.window.document;
function getVars(){
  const styles = dom.window.getComputedStyle(document.documentElement);
  return {bg: styles.getPropertyValue('--bg').trim(), text: styles.getPropertyValue('--text').trim()};
}
console.log('default', getVars());
document.documentElement.classList.add('dark');
console.log('dark', getVars());
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a81318494483319987b8a7a5c209c8